### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: '0 6 1,14,28 * *'
 
+permissions:
+  contents: read
+  actions: write
+  checks: write
+  pull-requests: write
+
 jobs:
   style:
     name: Check Style


### PR DESCRIPTION
Potential fix for [https://github.com/nathansam/bibget/security/code-scanning/3](https://github.com/nathansam/bibget/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the following permissions are needed:
- `contents: read` for accessing the repository contents.
- `actions: write` for uploading artifacts in the `Coverage` job.
- `checks: write` for reporting test results or coverage status (if applicable).
- `pull-requests: write` for interacting with pull requests (if applicable).

The `permissions` block will be added at the root level to apply to all jobs in the workflow. If specific jobs require different permissions, additional `permissions` blocks can be added at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
